### PR TITLE
Restore landing experience and stabilize resume uploads

### DIFF
--- a/src/pages/api/upload.ts
+++ b/src/pages/api/upload.ts
@@ -1,18 +1,57 @@
 import type { NextApiRequest, NextApiResponse } from "next";
+import formidable, { type Fields, type Files } from "formidable";
+import fs from "node:fs/promises";
+import { parsePdf } from "../../lib/pdf";
 
 export const config = {
-  api: { bodyParser: { sizeLimit: "10mb" } }
+  api: {
+    bodyParser: false,
+  },
 };
+
+function parseForm(req: NextApiRequest) {
+  const form = formidable({ multiples: false });
+
+  return new Promise<{ fields: Fields; files: Files }>((resolve, reject) => {
+    form.parse(req, (err, fields, files) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve({ fields, files });
+    });
+  });
+}
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
-    if (req.method !== "POST") return res.status(405).send("Method Not Allowed");
+    if (req.method !== "POST") {
+      res.status(405).send("Method Not Allowed");
+      return;
+    }
 
-    if (!req.body || !req.body.file) return res.status(400).send("No file uploaded");
+    const { files } = await parseForm(req);
+    const uploaded = files.file;
 
-    // Simply return the file for parsing later
-    res.status(200).json({ file: req.body.file });
+    if (!uploaded) {
+      res.status(400).send("No file uploaded");
+      return;
+    }
 
+    const fileArray = Array.isArray(uploaded) ? uploaded : [uploaded];
+    const file = fileArray[0];
+
+    if (!file || !file.filepath) {
+      res.status(400).send("Invalid file payload");
+      return;
+    }
+
+    const buffer = await fs.readFile(file.filepath);
+    const text = await parsePdf(buffer);
+
+    await fs.unlink(file.filepath).catch(() => {});
+
+    res.status(200).json({ text });
   } catch (err: any) {
     console.error("Upload Error:", err);
     res.status(500).send("Error uploading file: " + err.message);

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,12 +11,11 @@ import {
   UserCheck,
   Wand2,
   Zap,
-  Upload,
-  Bookmark
 } from "lucide-react";
 import { useState } from "react";
 import ResumeForm from "../components/ResumeForm";
 import UploadForm from "../components/UploadForm";
+import TemplatePreview from "../components/TemplatePreview";
 
 const stats = [
   {
@@ -123,6 +122,19 @@ export default function Home() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [parsedText, setParsedText] = useState<string | null>(null);
 
+  const parsedHtml = parsedText
+    ? parsedText
+        .split(/\n{2,}/)
+        .map((paragraph) =>
+          `<p>${paragraph
+            .split(/\n/)
+            .map((line) => line.trim())
+            .filter(Boolean)
+            .join("<br />")}</p>`
+        )
+        .join("")
+    : null;
+
   return (
     <main className="relative min-h-screen overflow-hidden text-slate-100">
       <div className="pointer-events-none absolute inset-0">
@@ -207,7 +219,202 @@ export default function Home() {
             )}
           </AnimatePresence>
         </header>
-        {/* Hero, Stats, Workspace, Features, Footer remain the same */}
+
+        {/* Hero */}
+        <motion.section
+          id="hero"
+          initial="hidden"
+          animate="visible"
+          variants={fadeUp}
+          className="mb-16 grid gap-12 lg:grid-cols-[1.1fr_0.9fr] lg:items-center"
+        >
+          <div className="space-y-6">
+            <p className="pill-button w-fit bg-white/10 text-xs uppercase tracking-[0.35em] text-indigo-100">
+              AI resume workspace
+            </p>
+            <h1 className="text-4xl font-semibold leading-tight text-white md:text-5xl">
+              Launch polished resumes in minutes with guided AI drafting
+            </h1>
+            <p className="max-w-xl text-lg text-slate-200">
+              EdgeWorks Creator Studio blends precise prompts with intuitive editing so every application reflects your best wins.
+            </p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link href="#workspace" className="btn-primary">
+                <Plus className="h-4 w-4" /> Generate a new resume
+              </Link>
+              <Link href="#features" className="btn-secondary">
+                Explore highlights
+              </Link>
+            </div>
+          </div>
+
+          <motion.div
+            variants={cardFade}
+            className="glass-panel relative overflow-hidden rounded-3xl border-white/5 bg-white/10 p-8"
+          >
+            <div className="absolute inset-0 bg-gradient-to-br from-indigo-500/10 to-purple-500/5" />
+            <div className="relative space-y-4">
+              <p className="text-sm uppercase tracking-[0.3em] text-indigo-100">Live editor</p>
+              <p className="text-lg text-slate-100">
+                Upload an existing PDF or craft new content — Creator Studio keeps context synced while AI drafts tailored achievements.
+              </p>
+              <div className="rounded-2xl border border-white/10 bg-black/30 p-4 text-sm text-slate-200">
+                “Repositioned onboarding to spotlight measurable growth, accelerating recruiter callbacks by 3x.”
+              </div>
+            </div>
+          </motion.div>
+        </motion.section>
+
+        {/* Stats */}
+        <motion.section
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={stagger}
+          className="mb-20 grid gap-4 sm:grid-cols-3"
+        >
+          {stats.map((stat) => (
+            <motion.div key={stat.label} variants={cardFade} className="floating-card flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-white">
+                <stat.icon className="h-5 w-5" />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-300">{stat.label}</p>
+                <p className="text-2xl font-semibold text-white">{stat.value}</p>
+                <p className={`text-sm text-slate-300 ${stat.badgeColor ?? ""}`}>{stat.caption}</p>
+              </div>
+            </motion.div>
+          ))}
+        </motion.section>
+
+        {/* Workspace */}
+        <motion.section
+          id="workspace"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2 }}
+          variants={cardStagger}
+          className="mb-24 space-y-10"
+        >
+          <div className="flex flex-col gap-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-indigo-200">Workspace</p>
+            <h2 className="text-3xl font-semibold text-white md:text-4xl">Build, remix, and export in one flow</h2>
+            <p className="max-w-2xl text-slate-200">
+              Parse an existing resume for quick tweaks or draft a brand-new version using guided prompts. Download ready-to-send PDFs in a click.
+            </p>
+          </div>
+
+          <div className="grid gap-8 lg:grid-cols-2">
+            <motion.div variants={cardFade} className="floating-card">
+              <h3 className="text-xl font-semibold text-white">Import an existing resume</h3>
+              <p className="mt-2 text-sm text-slate-300">
+                We’ll scan the PDF, pull out clean text, and prep it for editing.
+              </p>
+              <div className="mt-6">
+                <UploadForm onParsed={setParsedText} />
+              </div>
+              {parsedText && (
+                <div className="mt-6 rounded-2xl border border-white/10 bg-black/30 p-5 text-sm text-slate-200">
+                  <p className="mb-2 font-semibold text-white">Quick extract</p>
+                  <p className="whitespace-pre-wrap text-slate-200/90">{parsedText.slice(0, 500)}{parsedText.length > 500 ? "…" : ""}</p>
+                </div>
+              )}
+            </motion.div>
+
+            <motion.div variants={cardFade} className="floating-card">
+              <h3 className="text-xl font-semibold text-white">Draft a fresh version</h3>
+              <p className="mt-2 text-sm text-slate-300">
+                Share your highlights and we’ll compile a polished PDF using our Gemini-backed renderer.
+              </p>
+              <div className="mt-6">
+                <ResumeForm />
+              </div>
+            </motion.div>
+          </div>
+
+          {parsedHtml && (
+            <motion.div variants={cardFade} className="floating-card border border-white/10 bg-white/5">
+              <h3 className="text-xl font-semibold text-white">Parsed preview</h3>
+              <p className="mt-2 text-sm text-slate-300">
+                Cleaned HTML ready for remixing in the AI writer.
+              </p>
+              <TemplatePreview html={parsedHtml} />
+            </motion.div>
+          )}
+        </motion.section>
+
+        {/* Features */}
+        <motion.section
+          id="features"
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={stagger}
+          className="mb-24"
+        >
+          <div className="mb-10 space-y-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-indigo-200">Highlights</p>
+            <h2 className="text-3xl font-semibold text-white md:text-4xl">Why creators pick EdgeWorks</h2>
+            <p className="max-w-3xl text-slate-200">
+              Powerful automations remove the busywork so you can focus on curating stories that convert interviews.
+            </p>
+          </div>
+
+          <div className="grid gap-6 md:grid-cols-3">
+            {features.map((feature) => (
+              <motion.div key={feature.title} variants={cardFade} className="floating-card space-y-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/10 text-white">
+                  <feature.icon className="h-5 w-5" />
+                </div>
+                <h3 className="text-xl font-semibold text-white">{feature.title}</h3>
+                <p className="text-sm text-slate-300">{feature.description}</p>
+              </motion.div>
+            ))}
+          </div>
+        </motion.section>
+
+        {/* Timeline */}
+        <motion.section
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={stagger}
+          className="mb-24"
+        >
+          <div className="mb-8 space-y-3">
+            <p className="text-xs uppercase tracking-[0.3em] text-indigo-200">Workflow</p>
+            <h2 className="text-3xl font-semibold text-white md:text-4xl">From upload to share-ready in three steps</h2>
+          </div>
+
+          <div className="space-y-6">
+            {timeline.map((step, index) => (
+              <motion.div key={step.title} variants={cardFade} className="floating-card flex flex-col gap-3 md:flex-row md:items-center">
+                <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-white/10 text-lg font-semibold text-white">
+                  {index + 1}
+                </div>
+                <div>
+                  <h3 className="text-xl font-semibold text-white">{step.title}</h3>
+                  <p className="text-sm text-slate-300">{step.description}</p>
+                </div>
+              </motion.div>
+            ))}
+          </div>
+        </motion.section>
+
+        {/* Footer */}
+        <footer className="mt-auto border-t border-white/10 pt-10 text-sm text-slate-400">
+          <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-center">
+            <p>© {new Date().getFullYear()} EdgeWorks Creator Studio. All rights reserved.</p>
+            <div className="flex items-center gap-6">
+              <Link href="#hero" className="transition hover:text-white">
+                Back to top
+              </Link>
+              <Link href="mailto:hello@edgeworks.ai" className="transition hover:text-white">
+                Contact support
+              </Link>
+            </div>
+          </div>
+        </footer>
       </div>
     </main>
   );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/types/formidable.d.ts
+++ b/types/formidable.d.ts
@@ -1,0 +1,35 @@
+declare module "formidable" {
+  import type { IncomingMessage } from "http";
+
+  interface File {
+    filepath: string;
+    originalFilename?: string | null;
+    mimetype?: string | null;
+    size: number;
+  }
+
+  interface Files {
+    [key: string]: File | File[];
+  }
+
+  interface Fields {
+    [key: string]: undefined | string | string[];
+  }
+
+  interface Options {
+    multiples?: boolean;
+  }
+
+  class IncomingForm {
+    constructor(options?: Options);
+    parse(
+      req: IncomingMessage,
+      callback: (err: any, fields: Fields, files: Files) => void
+    ): void;
+  }
+
+  function formidable(options?: Options): IncomingForm;
+
+  export { File, Files, Fields, Options, IncomingForm };
+  export default formidable;
+}


### PR DESCRIPTION
## Summary
- rebuild the landing page with animated hero, stats, workspace, and feature sections wired to the existing forms
- surface parsed resume previews after uploads and connect the upload form to a real PDF parsing backend
- add a local formidable module declaration and update TypeScript config to include custom types

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9fc8f08e083309673056fa728e2fc